### PR TITLE
Update Shoko dev builds

### DIFF
--- a/pkgs/shoko-dev/deps.json
+++ b/pkgs/shoko-dev/deps.json
@@ -1225,11 +1225,6 @@
     "hash": "sha256-/giVqikworG2XKqfN9uLyjUSXr35zBuZ2FX2r8X/WUY="
   },
   {
-    "pname": "Shoko.Plugin.Abstractions",
-    "version": "4.0.0-beta5",
-    "hash": "sha256-Tc3cOHkEFjaqWTdHvAscMUfOawH5fc93/u2ztXWGtSc="
-  },
-  {
     "pname": "SQLitePCLRaw.bundle_e_sqlite3",
     "version": "2.1.6",
     "hash": "sha256-dZD/bZsYXjOu46ZH5Y/wgh0uhHOqIxC+S+0ecKhr718="
@@ -1298,11 +1293,6 @@
     "pname": "System.Buffers",
     "version": "4.5.0",
     "hash": "sha256-THw2znu+KibfJRfD7cE3nRYHsm7Fyn5pjOOZVonFjvs="
-  },
-  {
-    "pname": "System.Buffers",
-    "version": "4.5.1",
-    "hash": "sha256-wws90sfi9M7kuCPWkv1CEYMJtCqx9QB/kj0ymlsNaxI="
   },
   {
     "pname": "System.ClientModel",
@@ -1628,11 +1618,6 @@
     "pname": "System.Net.WebSockets.WebSocketProtocol",
     "version": "4.5.1",
     "hash": "sha256-5g6C2vb0RCUiSBw/tlCUbmrIbCvT9zQ+w/45o3l6Ctg="
-  },
-  {
-    "pname": "System.Numerics.Vectors",
-    "version": "4.4.0",
-    "hash": "sha256-auXQK2flL/JpnB/rEcAcUm4vYMCYMEMiWOCAlIaqu2U="
   },
   {
     "pname": "System.Numerics.Vectors",

--- a/pkgs/shoko-dev/package.nix
+++ b/pkgs/shoko-dev/package.nix
@@ -10,13 +10,13 @@
 }:
 buildDotnetModule (finalAttrs: {
   pname = "shoko-dev";
-  version = "5.1.0-dev.122";
+  version = "5.1.0-dev.125";
 
   src = fetchFromGitHub {
     owner = "ShokoAnime";
     repo = "ShokoServer";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-S4fzPCYjEaZqcMj/6TwpY0X/yl3s1tloN+LP4xEDcEg=";
+    hash = "sha256-nOu88JpON0vZINBiFux4hqPoSB+/w4dTBo91YtFeBgE=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/shoko-webui-dev/package.nix
+++ b/pkgs/shoko-webui-dev/package.nix
@@ -10,13 +10,13 @@
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "shoko-webui-dev";
-  version = "2.3.0-dev.6";
+  version = "2.3.0-dev.11";
 
   src = fetchFromGitHub {
     owner = "ShokoAnime";
     repo = "Shoko-WebUI";
     tag = "v${finalAttrs.version}";
-    hash = lib.fakeHash;
+    hash = "sha256-M+Qzyc5ll1Y/5tOaen14lI+i18sYAoudcmftE3UGUaI=";
     leaveDotGit = true;
   };
 
@@ -29,7 +29,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   pnpmDeps = pnpm.fetchDeps {
     inherit (finalAttrs) pname version src;
     fetcherVersion = 2;
-    hash = lib.fakeHash;
+    hash = "sha256-+w9hQhameF72TQmux0dM3X7w4S/JF9Bt09JJGAY59wg=";
   };
 
   buildPhase = ''


### PR DESCRIPTION
Automated update of Shoko development builds.

- **Server**: 5.1.0-dev.125
- **WebUI**: 2.3.0-dev.11

These updates were automatically detected from the upstream repositories.