### PR TITLE
Update bypass-paywalls-clean to 4.2.0.6

### DIFF
--- a/pkgs/bypass-paywalls-clean.nix
+++ b/pkgs/bypass-paywalls-clean.nix
@@ -5,10 +5,10 @@
 }:
 inputs.firefox-addons.lib.${stdenv.hostPlatform.system}.buildFirefoxXpiAddon rec {
   pname = "bypass-paywalls-clean";
-  version = "4.2.0.0";
+  version = "4.2.0.6";
   addonId = "magnolia@12.34";
   url = "https://gitflic.ru/project/magnolia1234/bpc_uploads/blob/raw?file=bypass_paywalls_clean-${version}.xpi";
-  sha256 = "sha256-hMMo27lBbVH5Buq3mIwXFIZPDaVUrvKygLctRpAElFc=";
+  sha256 = "sha256-sFcIlR0wgmXiJovqw+10Mh+qaMl5heIvHntk6DeC3TU=";
   meta = with lib; {
     homepage = "https://twitter.com/Magnolia1234B";
     description = "Bypass Paywalls of (custom) news sites";


### PR DESCRIPTION
Automated update of bypass-paywalls-clean Firefox extension.

- **Version**: 4.2.0.6
- **Hash**: sha256-sFcIlR0wgmXiJovqw+10Mh+qaMl5heIvHntk6DeC3TU=

This update was automatically detected from the upstream repository.