### PR TITLE
Update Shoko dev builds

### DIFF
--- a/pkgs/shoko-webui-dev/package.nix
+++ b/pkgs/shoko-webui-dev/package.nix
@@ -10,13 +10,13 @@
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "shoko-webui-dev";
-  version = "2.3.0-dev.11";
+  version = "2.3.0-dev.13";
 
   src = fetchFromGitHub {
     owner = "ShokoAnime";
     repo = "Shoko-WebUI";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-M+Qzyc5ll1Y/5tOaen14lI+i18sYAoudcmftE3UGUaI=";
+    hash = "sha256-Nw5spX796DeDe1hKRlqqwg9+vRwlK8dJB4gaMEGOPxU=";
     leaveDotGit = true;
   };
 


### PR DESCRIPTION
Automated update of Shoko development builds.


- **WebUI**: 2.3.0-dev.13

These updates were automatically detected from the upstream repositories.